### PR TITLE
feat: add testifysec platform defaults for zero-config signing

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ This action is pre-configured with TestifySec Platform URLs:
 
 | Setting | Default Value |
 |---------|---------------|
-| `archivista-server` | `https://archivista.platform.testifysec.com` |
+| `archivista-server` | `https://gateway.platform.testifysec.com` |
 | `fulcio` | `https://fulcio.platform.testifysec.com` |
 | `fulcio-oidc-issuer` | `https://token.actions.githubusercontent.com` |
 | `fulcio-oidc-client-id` | `sigstore` |
@@ -112,7 +112,7 @@ Override any defaults as needed:
 | Input | Description | Default |
 |-------|-------------|---------|
 | `enable-archivista` | Enable Archivista storage | `true` |
-| `archivista-server` | Archivista server URL | `https://archivista.platform.testifysec.com` |
+| `archivista-server` | Archivista server URL | `https://gateway.platform.testifysec.com` |
 
 See [action.yml](action.yml) for the complete list of inputs including KMS, Vault, and SPIFFE signer options.
 

--- a/README.md
+++ b/README.md
@@ -1,32 +1,133 @@
-# Witness Run Wrapper Action
+# Witness Wrapper Action
 
-A lightweight GitHub Action that reuses the Witness run action's wrapper flow so you can capture attestation for steps that run other actions or ad-hoc commands.
+A lightweight GitHub Action that wraps other actions or commands to capture attestations with [Witness](https://github.com/in-toto/witness). Pre-configured with TestifySec Platform defaults for zero-config Sigstore signing and timestamping.
 
-This repository pulls the wrapper-related pieces from the `feature/complete-rewrite-squashed` branch of [`testifysec/witness-run-action`](https://github.com/testifysec/witness-run-action) and keeps the Witness integration intact. The result is a slimmer action dedicated to wrapping other actions while still downloading Witness, constructing the correct CLI arguments, and handling environment propagation.
+## Quick Start
 
-## Usage
+With the new defaults, you only need to provide your step name, command, and API token:
 
 ```yaml
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # Required for OIDC authentication with Fulcio
+      contents: read
     steps:
-      - uses: actions/checkout@v4
-      - name: Wrap a downstream action
-        uses: colek42/witness-run-wrapper-action@main
+      - uses: testifysec/witness-wrapper@main
         with:
-          step: wrap-npm-test
-          action-ref: actions/setup-node@v4
-          witness_version: 0.8.1
-          attestations: "environment git github"
+          step: build
+          command: npm run build
+        env:
+          ARCHIVISTA_HEADERS: 'Authorization: Token ${{ secrets.WITNESS_API_TOKEN }}'
 ```
 
-Inputs mirror the original Witness run action so you can continue to configure attestors, Archivista, signer settings, and other Witness flags. Either `action-ref` or `command` must be provided (use `docker://` references when you need both).
+That's it! The action automatically:
+- Signs attestations using TestifySec's Fulcio CA (keyless signing via OIDC)
+- Timestamps with TestifySec's TSA for long-term verification
+- Uploads attestations to TestifySec's Archivista
+
+## Wrapping Other Actions
+
+You can wrap existing GitHub Actions to capture attestations for their execution:
+
+```yaml
+- uses: testifysec/witness-wrapper@main
+  with:
+    step: checkout
+    action-ref: actions/checkout@v4
+    attestations: 'git github environment'
+  env:
+    ARCHIVISTA_HEADERS: 'Authorization: Token ${{ secrets.WITNESS_API_TOKEN }}'
+
+- uses: testifysec/witness-wrapper@main
+  with:
+    step: setup-node
+    action-ref: actions/setup-node@v4
+  env:
+    ARCHIVISTA_HEADERS: 'Authorization: Token ${{ secrets.WITNESS_API_TOKEN }}'
+```
+
+## Platform Defaults
+
+This action is pre-configured with TestifySec Platform URLs:
+
+| Setting | Default Value |
+|---------|---------------|
+| `archivista-server` | `https://archivista.platform.testifysec.com` |
+| `fulcio` | `https://fulcio.platform.testifysec.com` |
+| `fulcio-oidc-issuer` | `https://token.actions.githubusercontent.com` |
+| `fulcio-oidc-client-id` | `sigstore` |
+| `timestamp-servers` | `https://tsa.platform.testifysec.com/api/v1/timestamp` |
+| `enable-sigstore` | `true` |
+| `enable-archivista` | `true` |
+
+## Custom Configuration
+
+Override any defaults as needed:
+
+```yaml
+- uses: testifysec/witness-wrapper@main
+  with:
+    step: build
+    command: make build
+    # Override defaults for self-hosted infrastructure
+    archivista-server: 'https://archivista.mycompany.com'
+    fulcio: 'https://fulcio.mycompany.com'
+    timestamp-servers: 'https://tsa.mycompany.com/api/v1/timestamp'
+  env:
+    ARCHIVISTA_HEADERS: 'Authorization: Token ${{ secrets.WITNESS_API_TOKEN }}'
+```
+
+## Inputs
+
+### Required
+
+| Input | Description |
+|-------|-------------|
+| `step` | Name of the step being run |
+| `command` or `action-ref` | Command to run, or reference to a GitHub Action (format: `owner/repo@ref`) |
+
+### Common Options
+
+| Input | Description | Default |
+|-------|-------------|---------|
+| `attestations` | Attestations to record | `environment git github` |
+| `witness_version` | Version of Witness CLI | Latest |
+| `outfile` | File to write signed data | - |
+| `workingdir` | Working directory for commands | - |
+
+### Sigstore Options
+
+| Input | Description | Default |
+|-------|-------------|---------|
+| `enable-sigstore` | Enable Sigstore signing | `true` |
+| `fulcio` | Fulcio CA address | `https://fulcio.platform.testifysec.com` |
+| `fulcio-oidc-issuer` | OIDC issuer URL | `https://token.actions.githubusercontent.com` |
+| `fulcio-oidc-client-id` | OIDC client ID | `sigstore` |
+| `timestamp-servers` | TSA server URL | `https://tsa.platform.testifysec.com/api/v1/timestamp` |
+
+### Archivista Options
+
+| Input | Description | Default |
+|-------|-------------|---------|
+| `enable-archivista` | Enable Archivista storage | `true` |
+| `archivista-server` | Archivista server URL | `https://archivista.platform.testifysec.com` |
+
+See [action.yml](action.yml) for the complete list of inputs including KMS, Vault, and SPIFFE signer options.
+
+## Permissions
+
+For OIDC authentication with Fulcio, your workflow needs the `id-token: write` permission:
+
+```yaml
+permissions:
+  id-token: write
+  contents: read
+```
 
 ## Development
 
-- Install dependencies with `npm install`
-- Build the bundled action with `npm run build`
-- Run locally via `node index.js` (ensuring required inputs are set in the environment)
-
-After making changes, commit and push to publish a new version tag for GitHub Actions consumers.
+- Install dependencies: `npm install`
+- Build the bundled action: `npm run build`
+- Run locally: `node index.js` (with required inputs set in environment)

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ jobs:
           step: build
           command: npm run build
         env:
-          ARCHIVISTA_HEADERS: 'Authorization: Token ${{ secrets.WITNESS_API_TOKEN }}'
+          ARCHIVISTA_HEADERS: 'Authorization: Token ${{ secrets.TESTIFYSEC_API_TOKEN }}'
 ```
 
 That's it! The action automatically:
@@ -38,14 +38,14 @@ You can wrap existing GitHub Actions to capture attestations for their execution
     action-ref: actions/checkout@v4
     attestations: 'git github environment'
   env:
-    ARCHIVISTA_HEADERS: 'Authorization: Token ${{ secrets.WITNESS_API_TOKEN }}'
+    ARCHIVISTA_HEADERS: 'Authorization: Token ${{ secrets.TESTIFYSEC_API_TOKEN }}'
 
 - uses: testifysec/witness-wrapper@main
   with:
     step: setup-node
     action-ref: actions/setup-node@v4
   env:
-    ARCHIVISTA_HEADERS: 'Authorization: Token ${{ secrets.WITNESS_API_TOKEN }}'
+    ARCHIVISTA_HEADERS: 'Authorization: Token ${{ secrets.TESTIFYSEC_API_TOKEN }}'
 ```
 
 ## Platform Defaults
@@ -76,7 +76,7 @@ Override any defaults as needed:
     fulcio: 'https://fulcio.mycompany.com'
     timestamp-servers: 'https://tsa.mycompany.com/api/v1/timestamp'
   env:
-    ARCHIVISTA_HEADERS: 'Authorization: Token ${{ secrets.WITNESS_API_TOKEN }}'
+    ARCHIVISTA_HEADERS: 'Authorization: Token ${{ secrets.TESTIFYSEC_API_TOKEN }}'
 ```
 
 ## Inputs

--- a/action.yml
+++ b/action.yml
@@ -44,7 +44,7 @@ inputs:
   archivista-server:
     description: "URL of the Archivista server to store or retrieve attestations"
     required: false
-    default: "https://archivista.testifysec.io"
+    default: "https://archivista.platform.testifysec.com"
   
   # Attestor settings
   attestor-link-export:
@@ -78,12 +78,15 @@ inputs:
   fulcio:
     description: "Fulcio address to sign with"
     required: false
+    default: "https://fulcio.platform.testifysec.com"
   fulcio-oidc-client-id:
     description: "OIDC client ID to use for authentication"
     required: false
+    default: "sigstore"
   fulcio-oidc-issuer:
     description: "OIDC issuer to use for authentication"
     required: false
+    default: "https://token.actions.githubusercontent.com"
   fulcio-oidc-redirect-url:
     description: "OIDC redirect URL (Optional). The default oidc-redirect-url is 'http://localhost:0/auth/callback'"
     required: false
@@ -177,6 +180,7 @@ inputs:
   timestamp-servers:
     description: "Timestamp Authority Servers to use when signing envelope"
     required: false
+    default: "https://tsa.platform.testifysec.com/api/v1/timestamp"
   
   # Hash settings
   hashes:

--- a/action.yml
+++ b/action.yml
@@ -44,7 +44,7 @@ inputs:
   archivista-server:
     description: "URL of the Archivista server to store or retrieve attestations"
     required: false
-    default: "https://archivista.platform.testifysec.com"
+    default: "https://gateway.platform.testifysec.com"
   
   # Attestor settings
   attestor-link-export:

--- a/dist/action.yml
+++ b/dist/action.yml
@@ -44,7 +44,7 @@ inputs:
   archivista-server:
     description: "URL of the Archivista server to store or retrieve attestations"
     required: false
-    default: "https://archivista.testifysec.io"
+    default: "https://archivista.platform.testifysec.com"
   
   # Attestor settings
   attestor-link-export:
@@ -78,12 +78,15 @@ inputs:
   fulcio:
     description: "Fulcio address to sign with"
     required: false
+    default: "https://fulcio.platform.testifysec.com"
   fulcio-oidc-client-id:
     description: "OIDC client ID to use for authentication"
     required: false
+    default: "sigstore"
   fulcio-oidc-issuer:
     description: "OIDC issuer to use for authentication"
     required: false
+    default: "https://token.actions.githubusercontent.com"
   fulcio-oidc-redirect-url:
     description: "OIDC redirect URL (Optional). The default oidc-redirect-url is 'http://localhost:0/auth/callback'"
     required: false
@@ -177,6 +180,7 @@ inputs:
   timestamp-servers:
     description: "Timestamp Authority Servers to use when signing envelope"
     required: false
+    default: "https://tsa.platform.testifysec.com/api/v1/timestamp"
   
   # Hash settings
   hashes:

--- a/dist/action.yml
+++ b/dist/action.yml
@@ -44,7 +44,7 @@ inputs:
   archivista-server:
     description: "URL of the Archivista server to store or retrieve attestations"
     required: false
-    default: "https://archivista.platform.testifysec.com"
+    default: "https://gateway.platform.testifysec.com"
   
   # Attestor settings
   attestor-link-export:


### PR DESCRIPTION
## Summary

This PR updates the action with TestifySec Platform defaults so users can get started with minimal configuration. Users now only need to provide:

- `step` name
- `command` or `action-ref`
- API token via `ARCHIVISTA_HEADERS` environment variable

Everything else just works out of the box with Sigstore signing and timestamping.

## Changes

### New Defaults

| Setting | Old Default | New Default |
|---------|-------------|-------------|
| `archivista-server` | `https://archivista.testifysec.io` | `https://archivista.platform.testifysec.com` |
| `fulcio` | _(none)_ | `https://fulcio.platform.testifysec.com` |
| `fulcio-oidc-issuer` | _(none)_ | `https://token.actions.githubusercontent.com` |
| `fulcio-oidc-client-id` | _(none)_ | `sigstore` |
| `timestamp-servers` | _(none)_ | `https://tsa.platform.testifysec.com/api/v1/timestamp` |

### Simplified Usage

Before:
```yaml
- uses: testifysec/witness-wrapper@main
  with:
    step: build
    command: npm run build
    archivista-server: 'https://archivista.platform.testifysec.com'
    enable-sigstore: true
    fulcio: 'https://fulcio.platform.testifysec.com'
    fulcio-oidc-issuer: 'https://token.actions.githubusercontent.com'
    fulcio-oidc-client-id: 'sigstore'
    timestamp-servers: 'https://tsa.platform.testifysec.com/api/v1/timestamp'
  env:
    ARCHIVISTA_HEADERS: 'Authorization: Token ${{ secrets.WITNESS_API_TOKEN }}'
```

After:
```yaml
- uses: testifysec/witness-wrapper@main
  with:
    step: build
    command: npm run build
  env:
    ARCHIVISTA_HEADERS: 'Authorization: Token ${{ secrets.WITNESS_API_TOKEN }}'
```

### README Updates

- Completely rewritten with simplified quick start
- Added platform defaults table
- Added examples for wrapping actions
- Added custom configuration section for self-hosted users
- Documented required permissions for OIDC

## Test plan

- [ ] Test action with minimal config against TestifySec Platform
- [ ] Verify attestations are signed with Fulcio certificates
- [ ] Verify attestations are timestamped with TSA
- [ ] Verify attestations are uploaded to Archivista

🤖 Generated with [Claude Code](https://claude.com/claude-code)